### PR TITLE
refactor: remove unnecessary boxing: Class methods, Block body and Ca…

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -154,7 +154,7 @@ pub struct Call {
     pub uuid: Uuid,
     pub callee: Box<Expr>,
     pub paren: Token,
-    pub arguments: Vec<Box<Expr>>,
+    pub arguments: Vec<Expr>,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -104,11 +104,7 @@ impl Interpreter {
         Ok(())
     }
 
-    pub fn execute_block(
-        &mut self,
-        statements: &[Box<Stmt>],
-        env: Environment,
-    ) -> Result<(), Exit> {
+    pub fn execute_block(&mut self, statements: &Vec<Stmt>, env: Environment) -> Result<(), Exit> {
         let previous = Rc::clone(&self.env);
 
         self.env = Rc::new(RefCell::new(env.clone()));
@@ -561,7 +557,7 @@ impl StmtVisitor<Result<(), Exit>> for Interpreter {
         let mut methods = HashMap::new();
 
         for method in &stmt.methods {
-            if let Stmt::Function(ref m) = **method {
+            if let Stmt::Function(m) = &method {
                 let function = Function {
                     declaration: Box::new(m.clone()),
                     closure: Rc::clone(&self.env),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -129,7 +129,7 @@ impl Parser {
         let mut methods = Vec::new();
 
         while !self.check(&TokenType::RightBrace) && !self.is_at_end() {
-            methods.push(Box::new(self.function()?));
+            methods.push(self.function()?);
         }
 
         let _ = self.consume(
@@ -361,10 +361,10 @@ impl Parser {
         if let Some(inc) = increment {
             body = Stmt::Block(Block {
                 statements: vec![
-                    Box::new(body),
-                    Box::new(Stmt::Expression(Expression {
+                    body,
+                    Stmt::Expression(Expression {
                         expression: Box::new(inc),
-                    })),
+                    }),
                 ],
             })
         }
@@ -383,7 +383,7 @@ impl Parser {
 
         if let Some(init) = initializer {
             body = Stmt::Block(Block {
-                statements: vec![Box::new(init), Box::new(body)],
+                statements: vec![init, body],
             })
         }
 
@@ -455,11 +455,11 @@ impl Parser {
         }))
     }
 
-    fn block(&mut self) -> Result<Vec<Box<Stmt>>, ParserError> {
+    fn block(&mut self) -> Result<Vec<Stmt>, ParserError> {
         let mut statements = Vec::new();
 
         while !self.check(&TokenType::RightBrace) && !self.is_at_end() {
-            statements.push(Box::new(self.declaration()?));
+            statements.push(self.declaration()?);
         }
 
         self.consume(
@@ -709,7 +709,7 @@ impl Parser {
                     });
                 }
 
-                arguments.push(Box::new(self.expression()?));
+                arguments.push(self.expression()?);
 
                 if !self.match_token_type(&[TokenType::Comma]) {
                     break;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -71,7 +71,7 @@ impl<'a> Resolver<'a> {
         Ok(())
     }
 
-    fn resolve_box_stmt(&mut self, statements: &[Box<Stmt>]) -> Result<(), ResolverError> {
+    fn resolve_box_stmt(&mut self, statements: &Vec<Stmt>) -> Result<(), ResolverError> {
         for statement in statements {
             self.resolve_stmt(statement)?;
         }
@@ -357,7 +357,7 @@ impl StmtVisitor<Result<(), ResolverError>> for Resolver<'_> {
             .insert("this".to_owned(), true);
 
         for method in &stmt.methods {
-            if let Stmt::Function(ref m) = **method {
+            if let Stmt::Function(m) = &method {
                 let declaration = if m.name.get_lexeme() == "init" {
                     FunctionType::Initializer
                 } else {

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -77,7 +77,7 @@ pub struct Var {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Block {
-    pub statements: Vec<Box<Stmt>>,
+    pub statements: Vec<Stmt>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -97,7 +97,7 @@ pub struct While {
 pub struct Function {
     pub name: Token,
     pub params: Vec<Token>,
-    pub body: Vec<Box<Stmt>>,
+    pub body: Vec<Stmt>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -109,6 +109,6 @@ pub struct Return {
 #[derive(Debug, PartialEq, Clone)]
 pub struct Class {
     pub name: Token,
-    pub methods: Vec<Box<Stmt>>,
+    pub methods: Vec<Stmt>,
     pub super_class: Box<Option<Expr>>,
 }


### PR DESCRIPTION
refactor: remove unnecessary boxing: Class methods, Block body and Call arguments statements refer to elements already heap allocated, so boxing them again is unnecessary